### PR TITLE
Ruby 3.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [ubuntu-20.04, ubuntu-22.04]
-          ruby: [ 2.7, 3.0, 3.1 ]
+          ruby: [ 2.7, 3.0, 3.1, 3.2 ]
 
       runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Our fixes thus far has gained us Ruby 3.2 support.